### PR TITLE
#15 - Moved sorting functionality from `DefaultMerger` to `LTSDotWriter`

### DIFF
--- a/src/com/github/tno/gltsdiff/mergers/DefaultMerger.java
+++ b/src/com/github/tno/gltsdiff/mergers/DefaultMerger.java
@@ -10,7 +10,6 @@
 
 package com.github.tno.gltsdiff.mergers;
 
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -95,10 +94,7 @@ public class DefaultMerger<S, T, U extends LTS<S, T>> extends AbstractMerger<S, 
         Set<State<S>> rightMatchedStates = new LinkedHashSet<>();
 
         // 1.1 A combined state is added for every match in 'matching'.
-        // Note: Additional sorting is applied to get the state ordering more consistent with earlier implementations.
-        for (Entry<State<S>, State<S>> assignment: matching.entrySet().stream().sorted(matchingComparator())
-                .collect(Collectors.toList()))
-        {
+        for (Entry<State<S>, State<S>> assignment: matching.entrySet()) {
             State<S> leftState = assignment.getKey();
             State<S> rightState = assignment.getValue();
             leftMatchedStates.add(leftState);
@@ -145,19 +141,6 @@ public class DefaultMerger<S, T, U extends LTS<S, T>> extends AbstractMerger<S, 
         transitionCombiner.combine(leftTransitions, rightTransitions).forEach(diff::addTransition);
 
         return diff;
-    }
-
-    /** @return A comparator for state matchings that considers initial state arrows and state identifiers. */
-    private Comparator<Entry<State<S>, State<S>>> matchingComparator() {
-        return Comparator
-                // Firstly compare LHS initial states (descending order: first true, then false).
-                .comparing((Entry<State<S>, State<S>> entry) -> !lhs.isInitialState(entry.getKey()))
-                // Secondly compare RHS initial states (descending order: first true, then false).
-                .thenComparing(entry -> !rhs.isInitialState(entry.getValue()))
-                // Thirdly compare LHS state identifiers.
-                .thenComparing(entry -> entry.getKey().getId())
-                // Lastly compare RHS state identifiers.
-                .thenComparing(entry -> entry.getValue().getId());
     }
 
     /**

--- a/src/com/github/tno/gltsdiff/writers/LTSDotWriter.java
+++ b/src/com/github/tno/gltsdiff/writers/LTSDotWriter.java
@@ -171,6 +171,15 @@ public abstract class LTSDotWriter<S, T, U extends LTS<S, T>> {
         return DEFAULT_COLOR;
     }
 
+    /** @return A comparator that imposes a deterministic and total order on states. */
+    protected Comparator<State<S>> getStateComparator() {
+        return Comparator
+                // First compare initial state information (descending order: first true, then false).
+                .comparing((State<S> state) -> !lts.isInitialState(state))
+                // Then compare state identifiers.
+                .thenComparing(State::getId);
+    }
+
     private void writeState(Writer writer, State<S> state) throws IOException {
         String stateId = stateId(state);
         writer.write("\t");
@@ -227,6 +236,6 @@ public abstract class LTSDotWriter<S, T, U extends LTS<S, T>> {
      * @return A list of deterministically ordered states.
      */
     private List<State<S>> sortStates(Collection<State<S>> states) {
-        return states.stream().sorted(Comparator.comparing(State::getId)).collect(Collectors.toList());
+        return states.stream().sorted(getStateComparator()).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Addresses #15 

Just a minor remark: now sometimes the order in which `LTSDotWriter` writes/prints states and transitions is slightly different. This cannot really be avoided, since state identifiers are now assigned differently by the merger (i.e., initial states don't always have the lowest state id anymore).