### PR TITLE
#68 Lowered required version of org.apache.commons.math3: 3.6.1->3.5.0.

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: TNO
 Automatic-Module-Name: com.github.tno.gltsdiff
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.apache.commons.math3;bundle-version="3.6.1",
+Require-Bundle: org.apache.commons.math3;bundle-version="3.5.0",
  com.google.guava;bundle-version="27.1.0",
  org.apache.commons.lang;bundle-version="2.6.0"
 Export-Package: com.github.tno.gltsdiff,


### PR DESCRIPTION
Closes #68 