### PR TITLE
#69 Fixed LTS/automaton state property combiners.

### DIFF
--- a/src/com/github/tno/gltsdiff/operators/combiners/AutomatonStatePropertyCombiner.java
+++ b/src/com/github/tno/gltsdiff/operators/combiners/AutomatonStatePropertyCombiner.java
@@ -14,17 +14,18 @@ import com.github.tno.gltsdiff.glts.AutomatonStateProperty;
 
 /**
  * A combiner for {@link AutomatonStateProperty automaton state properties}. Any two such properties can be combined if
- * they agree on state acceptance (i.e., they either both indicate acceptance or both indicate non-acceptance).
- * Combining two such properties results in an automaton state property with combined initial state information.
+ * they agree on states being initial and accepting (i.e., either both states are initial and accepting or both states
+ * are not initial and not accepting). Combining two such properties results in an automaton state property with their
+ * equal initial state and state acceptance information.
  */
 public class AutomatonStatePropertyCombiner extends Combiner<AutomatonStateProperty> {
     @Override
     protected boolean computeAreCombinable(AutomatonStateProperty left, AutomatonStateProperty right) {
-        return left.isAccepting() == right.isAccepting();
+        return left.isInitial() == right.isInitial() && left.isAccepting() == right.isAccepting();
     }
 
     @Override
     protected AutomatonStateProperty computeCombination(AutomatonStateProperty left, AutomatonStateProperty right) {
-        return new AutomatonStateProperty(left.isInitial() || right.isInitial(), left.isAccepting());
+        return new AutomatonStateProperty(left.isInitial(), left.isAccepting());
     }
 }

--- a/src/com/github/tno/gltsdiff/operators/combiners/DiffAutomatonStatePropertyCombiner.java
+++ b/src/com/github/tno/gltsdiff/operators/combiners/DiffAutomatonStatePropertyCombiner.java
@@ -17,9 +17,9 @@ import com.github.tno.gltsdiff.glts.DiffKind;
 
 /**
  * A combiner for {@link DiffAutomatonStateProperty difference automaton state properties}. Any two such properties are
- * combinable if they agree on state acceptance (i.e., they either both indicate acceptance or both indicate
- * non-acceptance). Combining two such properties results in a difference automaton state property with a combined state
- * difference kind, and combined initial state (difference) information.
+ * combinable if they agree on states being accepting (i.e., both states are accepting or both states are
+ * non-accepting). Combining two such properties results in a difference automaton state property with a combined state
+ * difference kind, combined initial state (difference) information, and their equal state acceptance information.
  */
 public class DiffAutomatonStatePropertyCombiner extends Combiner<DiffAutomatonStateProperty> {
     /** The combiner for difference kinds. */

--- a/src/com/github/tno/gltsdiff/operators/combiners/LTSStatePropertyCombiner.java
+++ b/src/com/github/tno/gltsdiff/operators/combiners/LTSStatePropertyCombiner.java
@@ -13,17 +13,18 @@ package com.github.tno.gltsdiff.operators.combiners;
 import com.github.tno.gltsdiff.glts.LTSStateProperty;
 
 /**
- * A combiner for {@link LTSStateProperty LTS state properties}. Such properties are always combinable. Combining any
- * two such properties results in an LTS state property with combined initial state information.
+ * A combiner for {@link LTSStateProperty LTS state properties}. Any two such properties can be combined if they agree
+ * on states being initial (i.e., either both states are initial or both states are not initial). Combining two such
+ * properties results in an LTS state property with their equal initial state information.
  */
 public class LTSStatePropertyCombiner extends Combiner<LTSStateProperty> {
     @Override
     protected boolean computeAreCombinable(LTSStateProperty left, LTSStateProperty right) {
-        return true;
+        return left.isInitial() == right.isInitial();
     }
 
     @Override
     protected LTSStateProperty computeCombination(LTSStateProperty left, LTSStateProperty right) {
-        return new LTSStateProperty(left.isInitial() || right.isInitial());
+        return new LTSStateProperty(left.isInitial());
     }
 }


### PR DESCRIPTION
- They must use equality combiners for initial state information.

Closes #69