### PR TITLE
#123 POM changes for deployment to Maven Central.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.tno.gltsdiff</groupId>
+    <groupId>io.github.tno</groupId>
     <artifactId>com.github.tno.gltsdiff</artifactId>
     <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -203,7 +203,7 @@ SPDX-License-Identifier: MIT
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
@@ -211,12 +211,12 @@ SPDX-License-Identifier: MIT
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -268,11 +268,11 @@ SPDX-License-Identifier: MIT
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -297,7 +297,7 @@ SPDX-License-Identifier: MIT
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
- Update `groupId`. See https://issues.sonatype.org/browse/OSSRH-94083.
- Update Nexus URLs.
- Update several plugins to latest versions.
- Update Maven source plugin goal to what is recommended by Sonatype.

I haven't tested deployment yet. These are only preparations. We'll see when actually deploying whether it works.